### PR TITLE
 Add agent constraints — per-session and global guardrails (Settings UI + /constraints slash command)

### DIFF
--- a/src/commands/slash-command-catalog.ts
+++ b/src/commands/slash-command-catalog.ts
@@ -53,4 +53,5 @@ export const BUILTIN_SLASH_COMMANDS: BuiltinSlashCommandDefinition[] = [
 	{ name: "resume", description: "Open session browser, /resume <query> pre-fills search" },
 	{ name: "reload", description: "Reload runtime (bridge restart + state/models/commands refresh)" },
 	{ name: "quit", description: "Quit Desktop app" },
+	{ name: "constraints", description: "Open constraints settings — agent guardrails (per-session / global)" },
 ];

--- a/src/components/chat-view/send-message-flow.ts
+++ b/src/components/chat-view/send-message-flow.ts
@@ -1,4 +1,5 @@
 import { rpcBridge, type RpcImageInput, type RpcSessionState } from "../../rpc/bridge.js";
+import { getConstraintsPrefix } from "../../rpc/constraints.js";
 
 type NoticeKind = "info" | "success" | "error";
 
@@ -101,7 +102,7 @@ export async function sendMessageFlow<ImageItem>({
 	try {
 		const rpcImages = toRpcImages(images);
 		if (actualMode === "prompt") {
-			await rpcBridge.prompt(text, { images: rpcImages });
+			await rpcBridge.prompt(getConstraintsPrefix() + text, { images: rpcImages });
 		} else if (actualMode === "steer") {
 			await rpcBridge.steer(text, rpcImages);
 		} else {

--- a/src/components/chat-view/slash-builtin-command.ts
+++ b/src/components/chat-view/slash-builtin-command.ts
@@ -234,6 +234,14 @@ export async function executeBuiltinSlashCommand({
 			}
 			return;
 		}
+		case "constraints": {
+			if (onOpenSettings) {
+				onOpenSettings("constraints");
+			} else {
+				pushNotice("Settings panel is unavailable", "error");
+			}
+			return;
+		}
 		case "export": {
 			let outputPath = unwrapQuotedArg(args);
 			if (!outputPath) {

--- a/src/components/settings-panel.ts
+++ b/src/components/settings-panel.ts
@@ -61,7 +61,7 @@ interface ScopedModelOption {
 	name: string;
 }
 
-export type SettingsSectionId = "general" | "appearance" | "account" | "providers" | "updates";
+export type SettingsSectionId = "general" | "appearance" | "account" | "providers" | "updates" | "constraints";
 
 export interface SettingsSectionNavItem {
 	id: SettingsSectionId;
@@ -151,6 +151,12 @@ export class SettingsPanel {
 	private newProviderApiKey = "";
 	private providerTestResults: Record<string, { testing: boolean; ok?: boolean; message?: string }> = {};
 	private activeSection: SettingsSectionId = "general";
+	// Constraints
+	private globalConstraints: string[] = [];
+	private sessionConstraints: string[] = [];
+	private constraintInput = "";
+	private constraintScope: "global" | "session" = "session";
+	private onConstraintsChange: ((global: string[], session: string[]) => void) | null = null;
 
 	constructor(container: HTMLElement) {
 		this.container = container;
@@ -191,6 +197,41 @@ export class SettingsPanel {
 	setOnNavigationStateChange(callback: ((state: SettingsNavigationState) => void) | null): void {
 		this.onNavigationStateChange = callback;
 		if (callback) callback(this.getNavigationState());
+	}
+
+	setConstraints(globalConstraints: string[], sessionConstraints: string[]): void {
+		this.globalConstraints = [...globalConstraints];
+		this.sessionConstraints = [...sessionConstraints];
+		if (this.isOpen && this.activeSection === "constraints") this.render();
+	}
+
+	setOnConstraintsChange(callback: ((global: string[], session: string[]) => void) | null): void {
+		this.onConstraintsChange = callback;
+	}
+
+	private addConstraint(): void {
+		const text = this.constraintInput.trim();
+		if (!text) return;
+		if (this.constraintScope === "global") {
+			if (this.globalConstraints.includes(text)) return;
+			this.globalConstraints = [...this.globalConstraints, text];
+		} else {
+			if (this.sessionConstraints.includes(text)) return;
+			this.sessionConstraints = [...this.sessionConstraints, text];
+		}
+		this.constraintInput = "";
+		this.onConstraintsChange?.(this.globalConstraints, this.sessionConstraints);
+		this.render();
+	}
+
+	private removeConstraint(index: number): void {
+		if (this.constraintScope === "global") {
+			this.globalConstraints = this.globalConstraints.filter((_, i) => i !== index);
+		} else {
+			this.sessionConstraints = this.sessionConstraints.filter((_, i) => i !== index);
+		}
+		this.onConstraintsChange?.(this.globalConstraints, this.sessionConstraints);
+		this.render();
 	}
 
 	getActiveSection(): SettingsSectionId {
@@ -1915,6 +1956,11 @@ export class SettingsPanel {
 				label: "Updates",
 				description: "Desktop releases, CLI version, and runtime diagnostics.",
 			},
+			{
+				id: "constraints",
+				label: "Constraints",
+				description: "Agent guardrails — rules the agent must follow (per-session or global).",
+			},
 		];
 	}
 
@@ -2443,6 +2489,53 @@ export class SettingsPanel {
 		`;
 	}
 
+
+	private renderConstraintsSection(): TemplateResult {
+		const constraints = this.constraintScope === "global" ? this.globalConstraints : this.sessionConstraints;
+		return html`
+			<div class="settings-view-grid">
+				<section class="settings-group settings-group-full">
+					<div class="settings-section">
+						<div class="settings-section-title">Constraints</div>
+						<div class="settings-desc">Agent guardrails — rules the agent MUST follow. Use for things like "never edit config files" or "only work in src/".</div>
+						<div class="settings-row" style="margin-top:12px;">
+							<div>
+								<div class="settings-label">Scope</div>
+								<div class="settings-desc">Session constraints apply to the current project only. Global constraints apply everywhere.</div>
+							</div>
+							<select class="settings-select" .value=${this.constraintScope} @change=${(e: Event) => { this.constraintScope = (e.target as HTMLSelectElement).value as "global" | "session"; this.render(); }}>
+								<option value="session">Session</option>
+								<option value="global">Global</option>
+							</select>
+						</div>
+						<div class="settings-row" style="margin-top:10px;">
+							<input
+								class="settings-input"
+								type="text"
+								placeholder="Add a constraint (e.g. never edit .env files)"
+								.value=${this.constraintInput}
+								@input=${(e: Event) => { this.constraintInput = (e.target as HTMLInputElement).value; }}
+								@keydown=${(e: KeyboardEvent) => { if (e.key === "Enter") this.addConstraint(); }}
+							/>
+							<button class="settings-btn-primary" @click=${() => this.addConstraint()}>Add</button>
+						</div>
+						${constraints.length === 0
+							? html`<div class="settings-desc" style="margin-top:12px;">No ${this.constraintScope} constraints yet.</div>`
+							: html`
+								<div class="constraints-list" style="margin-top:12px;">
+									${constraints.map((c, i) => html`
+										<div class="settings-row constraints-item" style="margin-bottom:6px;">
+											<span class="constraints-text" style="flex:1;">${c}</span>
+											<button class="settings-btn-secondary" @click=${() => this.removeConstraint(i)} style="padding:2px 8px;">✕</button>
+										</div>
+									`)}
+								</div>
+							`}
+					</div>
+				</section>
+			</div>
+		`;
+	}
 	private renderActiveSection(
 		section: SettingsSectionId,
 		runtimeControlsEnabled: boolean,
@@ -2459,6 +2552,8 @@ export class SettingsPanel {
 				return this.renderAccountSection(runtimeControlsEnabled, hasProjectContext, authProviders);
 			case "updates":
 				return this.renderUpdatesSection(runtimeControlsEnabled, compatibilityChecks);
+			case "constraints":
+				return this.renderConstraintsSection();
 			case "general":
 			default:
 				return this.renderGeneralSection(runtimeControlsEnabled, hasProjectContext);

--- a/src/main.ts
+++ b/src/main.ts
@@ -30,6 +30,7 @@ import { ensureDesktopNotifyBridgeExtensionInstalled } from "./extensions/deskto
 import { isExtensionConfigIntent, normalizeExtensionCommandName } from "./extensions/extension-command-intent.js";
 import { ensureDesktopSdkCompatExtensionInstalled } from "./extensions/sdk-compat-extension.js";
 import { ensureSmartVoiceNotifyDesktopHostMode } from "./extensions/smart-voice-notify-config.js";
+import { setActiveSessionConstraints } from "./rpc/constraints.js";
 import "./styles/app.css";
 
 interface WorkspaceSessionTab {
@@ -71,6 +72,7 @@ interface WorkspaceState {
 	activeSessionTabId: string | null;
 	fileTabs: WorkspaceFileTab[];
 	activeFileTabId: string | null;
+	sessionConstraints: string[];
 }
 
 interface SessionRuntime {
@@ -100,6 +102,24 @@ const SIDEBAR_WIDTH_MAX = 540;
 const TERMINAL_DOCK_HEIGHT_KEY = "pi-desktop.terminal-dock-height.v1";
 const TERMINAL_DOCK_MIN_HEIGHT = 180;
 const TERMINAL_DOCK_MAX_HEIGHT = 640;
+const GLOBAL_CONSTRAINTS_STORAGE_KEY = "pi-desktop.global-constraints.v1";
+
+function loadGlobalConstraints(): string[] {
+	try {
+		const raw = localStorage.getItem(GLOBAL_CONSTRAINTS_STORAGE_KEY);
+		if (raw) {
+			const parsed = JSON.parse(raw);
+			if (Array.isArray(parsed)) return parsed.filter((c: unknown) => typeof c === "string" && c.trim().length > 0).map((c: string) => c.trim());
+		}
+	} catch { /* ignore */ }
+	return [];
+}
+
+function saveGlobalConstraints(constraints: string[]): void {
+	try {
+		localStorage.setItem(GLOBAL_CONSTRAINTS_STORAGE_KEY, JSON.stringify(constraints));
+	} catch { /* ignore */ }
+}
 const TERMINAL_DOCK_DEFAULT_HEIGHT = 280;
 const FILE_SPLIT_WIDTH_KEY = "pi-desktop.file-split-width.v1";
 const FILE_SPLIT_MIN_WIDTH = 300;
@@ -2115,7 +2135,6 @@ function ensureWorkspaceEmoji(workspace: WorkspaceState): boolean {
 	workspace.emoji = pickWorkspaceDefaultEmoji(`${workspace.id}:${workspace.title}`);
 	return true;
 }
-
 function defaultWorkspace(): WorkspaceState {
 	const seedSessionTab = createSessionTab(NEW_SESSION_TAB_TITLE, null);
 	return {
@@ -2135,6 +2154,7 @@ function defaultWorkspace(): WorkspaceState {
 		activeSessionTabId: seedSessionTab.id,
 		fileTabs: [],
 		activeFileTabId: null,
+		sessionConstraints: [],
 	};
 }
 
@@ -2159,6 +2179,7 @@ function createWorkspace(title?: string, emoji?: string | null): WorkspaceState 
 		activeSessionTabId: seedSessionTab.id,
 		fileTabs: [],
 		activeFileTabId: null,
+		sessionConstraints: [],
 	};
 }
 
@@ -2307,6 +2328,7 @@ function loadWorkspaces(): void {
 							typeof w.activeFileTabId === "string" && fileTabs.some((tab) => tab.id === w.activeFileTabId)
 								? w.activeFileTabId
 								: fileTabs[0]?.id ?? null,
+						sessionConstraints: Array.isArray(w.sessionConstraints) ? w.sessionConstraints.filter((c: unknown) => typeof c === "string" && c.trim().length > 0).map((c: string) => c.trim()) : [],
 					};
 
 					ensureWorkspaceContentState(workspace);
@@ -2522,6 +2544,7 @@ function syncActiveChatRuntimeBinding(
 		}
 		return;
 	}
+	setActiveSessionConstraints(workspace.sessionConstraints);
 	ensureWorkspaceContentState(workspace);
 	const activeSessionTab = getActiveSessionTab(workspace);
 	const projectPath = getSessionTabProjectPath(activeSessionTab) ?? getWorkspaceActiveProjectPath(workspace);
@@ -3495,6 +3518,15 @@ function mountSettingsPanel(): SettingsPanel {
 			chatView?.notify("Saved CLI binary path override. Use /reload to reconnect active runtimes.", "info");
 		}
 	});
+	panel.setOnConstraintsChange((globalConstraints, sessionConstraints) => {
+		saveGlobalConstraints(globalConstraints);
+		setActiveSessionConstraints(sessionConstraints);
+		const workspace = getActiveWorkspace();
+		if (workspace) {
+			workspace.sessionConstraints = sessionConstraints;
+			persistWorkspaces();
+		}
+	});
 	panel.setOnClose(() => {
 		const workspace = getActiveWorkspace();
 		if (!workspace || workspace.pane !== "settings") return;
@@ -3503,6 +3535,8 @@ function mountSettingsPanel(): SettingsPanel {
 		syncWorkspaceTabsBar();
 		void applyWorkspacePane(workspace);
 	});
+	const workspace = getActiveWorkspace();
+	panel.setConstraints(loadGlobalConstraints(), workspace?.sessionConstraints ?? []);
 	panel.setOnRequestAddProject(() => {
 		void sidebar?.openFolder();
 	});
@@ -3785,6 +3819,8 @@ function normalizeSettingsSectionId(sectionId: string | null | undefined): Setti
 			return "account";
 		case "updates":
 			return "updates";
+		case "constraints":
+			return "constraints";
 		default:
 			return null;
 	}
@@ -3801,6 +3837,7 @@ function requestOpenSettingsPanel(sectionId?: string): void {
 	try {
 		const panel = mountSettingsPanel();
 		panel.setRuntimeProjectPath(resolveSettingsRuntimeProjectPath(workspace));
+		panel.setConstraints(loadGlobalConstraints(), workspace.sessionConstraints);
 		if (targetSection) panel.setActiveSection(targetSection);
 	} catch (mountErr) {
 		console.error("Failed to prepare settings panel before open:", mountErr);
@@ -3810,9 +3847,9 @@ function requestOpenSettingsPanel(sectionId?: string): void {
 			console.error("Failed to open settings pane:", err);
 			try {
 				settingsPanel = null;
-				setPaneVisibility("settings");
 				const panel = mountSettingsPanel();
 				panel.setRuntimeProjectPath(resolveSettingsRuntimeProjectPath(workspace));
+				panel.setConstraints(loadGlobalConstraints(), workspace.sessionConstraints);
 				if (targetSection) panel.setActiveSection(targetSection);
 				void panel.open();
 			} catch (innerErr) {

--- a/src/rpc/constraints.ts
+++ b/src/rpc/constraints.ts
@@ -1,0 +1,32 @@
+// ponytail: module-level session constraints ref, set by main.ts on workspace switch.
+// Global constraints read from localStorage on each call so they stay fresh.
+
+const GLOBAL_KEY = "pi-desktop.global-constraints.v1";
+
+let _sessionConstraints: string[] = [];
+
+export function setActiveSessionConstraints(constraints: string[]): void {
+	_sessionConstraints = [...constraints];
+}
+
+function loadGlobalConstraints(): string[] {
+	try {
+		const raw = localStorage.getItem(GLOBAL_KEY);
+		if (raw) {
+			const parsed = JSON.parse(raw);
+			if (Array.isArray(parsed)) return parsed.filter((c: unknown) => typeof c === "string" && c.trim().length > 0).map((c: string) => c.trim());
+		}
+	} catch { /* ignore */ }
+	return [];
+}
+
+export function getActiveConstraints(): string[] {
+	return [...loadGlobalConstraints(), ..._sessionConstraints];
+}
+
+export function getConstraintsPrefix(): string {
+	const all = getActiveConstraints();
+	if (all.length === 0) return "";
+	const lines = all.map((c) => `- ${c}`).join("\n");
+	return `<constraints>\nThe following constraints are ACTIVE and MUST be respected. They are non-negotiable guardrails:\n${lines}\n</constraints>\n\n`;
+}


### PR DESCRIPTION
 Add agent constraints — per-session and global guardrails (Settings UI + /constraints slash command)

 Description:
 This PR adds a new Constraints feature that lets users set permanent guardrails the agent must follow — things like
 "never edit .env files" or "only work in src/."

 What it does:
 - New Constraints section in Settings with scope toggle (Session / Global), text input, Add and Remove buttons
 - /constraints slash command opens settings directly to the Constraints section
 - Constraints are prepended to every prompt as a <constraints> XML block the agent sees
 - Session constraints persist per-project in workspace state; global constraints persist across all projects in
 localStorage
 - Fully backward-compatible — old workspace data without constraints defaults to empty

 How to test:
 1. Open the app → Settings → Constraints (or type /constraints)
 2. Select "Global" scope, type "never edit .env files", click Add
 3. Switch to "Session" scope, add "only suggest changes, don't apply them"
 4. Go to chat, type a prompt — the agent receives both constraints
 5. Remove a constraint via the ✕ button
 6. Restart the app — global constraints persist, session constraints persist per project

 Files changed: 6 files, +178 −4
 - New: src/rpc/constraints.ts — shared module for constraint storage and prompt prefix generation
 - src/main.ts — workspace state field, persistence wiring, /constraints routing
 - src/components/settings-panel.ts — Constraints section UI and state
 - src/components/chat-view/send-message-flow.ts — prepend constraints to prompts
 - src/commands/slash-command-catalog.ts — /constraints registration
 - src/components/chat-view/slash-builtin-command.ts — /constraints handler

 Screenshot:
 
<img width="1135" height="488" alt="image" src="https://github.com/user-attachments/assets/a07d8052-bf53-433b-9473-bd90a5fb9a5d" />
